### PR TITLE
fix(deps): update nokogiri within ruby baseline

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,12 +116,13 @@ GEM
       treetop (~> 1.4.8)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.8.9)
     multi_json (1.7.9)
     net-ldap (0.3.1)
     netrc (0.11.0)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     open4 (1.0.1)
     polyglot (0.3.3)
     pry (0.9.12.2)
@@ -129,6 +130,7 @@ GEM
       method_source (~> 0.8)
       slop (~> 3.4)
     puma (3.12.6)
+    racc (1.8.1)
     rack (1.6.13)
     rack-protection (1.5.0)
       rack
@@ -211,3 +213,6 @@ DEPENDENCIES
   sinatra-flash
   slim
   sqlite3
+
+BUNDLED WITH
+   1.17.2


### PR DESCRIPTION
## Summary
- Supersedes #59 without moving this legacy app to Nokogiri 1.19, which requires Ruby >= 3.2.
- Updates the lockfile from Nokogiri 1.10.10 to 1.13.10, the newest Nokogiri release line I found that supports the current Ruby 2.6 runtime.
- Updates the matching transitive lock entries for `mini_portile2` and `racc`.

## Verification
- `bundle lock --update nokogiri --conservative`
- `bundle lock --update nokogiri --conservative --print` confirmed Nokogiri 1.13.10, mini_portile2 2.8.9, and racc 1.8.1.
- `gem specification nokogiri -r -v 1.13.10 required_ruby_version --yaml` reports Ruby >= 2.6.0.
- `bundle install --path vendor/bundle --without development production` installed Nokogiri 1.13.10 successfully, then failed later on existing `json 1.8.0` native compilation against the current macOS/Ruby headers.
- `git diff --check HEAD~1 HEAD`

## Notes
- Dependabot #59 cannot be merged as written: Nokogiri 1.19.3 requires Ruby >= 3.2, while the available repo runtime is Ruby 2.6.10 and `.travis.yml` advertises still older Rubies.
- Full test execution remains blocked by an existing native build failure in `json 1.8.0`; this PR does not introduce that dependency.